### PR TITLE
Split minimum launcher version by client/server

### DIFF
--- a/pkg/api/api0/api.go
+++ b/pkg/api/api0/api.go
@@ -70,10 +70,10 @@ type Handler struct {
 	// @BobTheBob9 for this option even existing in the first place.
 	InsecureDevNoCheckPlayerAuth bool
 
-	// MinimumLauncherVersion restricts authentication and server registration
+	// MinimumLauncherVersion* restricts authentication and server registration
 	// to clients with at least this version, which must be valid semver. +dev
 	// versions are always allowed.
-	MinimumLauncherVersion string
+	MinimumLauncherVersionClient, MinimumLauncherVersionServer string
 
 	// TokenExpiryTime controls the expiry of player masterserver auth tokens.
 	// If zero, a reasonable a default is used.
@@ -149,7 +149,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // CheckLauncherVersion checks if the r was made by NorthstarLauncher and if it
 // is at least MinimumLauncherVersion.
-func (h *Handler) CheckLauncherVersion(r *http.Request) bool {
+func (h *Handler) CheckLauncherVersion(r *http.Request, client bool) bool {
 	rver, _, _ := strings.Cut(r.Header.Get("User-Agent"), " ")
 	if x := strings.TrimPrefix(rver, "R2Northstar/"); rver != x {
 		if len(x) > 0 && x[0] != 'v' {
@@ -162,7 +162,12 @@ func (h *Handler) CheckLauncherVersion(r *http.Request) bool {
 		return false // deny: not R2Northstar
 	}
 
-	mver := h.MinimumLauncherVersion
+	var mver string
+	if client {
+		mver = h.MinimumLauncherVersionClient
+	} else {
+		mver = h.MinimumLauncherVersionServer
+	}
 	if mver != "" {
 		if mver[0] != 'v' {
 			mver = "v" + mver

--- a/pkg/api/api0/client.go
+++ b/pkg/api/api0/client.go
@@ -88,7 +88,7 @@ func (h *Handler) handleClientOriginAuth(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !h.CheckLauncherVersion(r) {
+	if !h.CheckLauncherVersion(r, true) {
 		h.m().client_originauth_requests_total.reject_versiongate.Inc()
 		respFail(w, r, http.StatusBadRequest, ErrorCode_UNSUPPORTED_VERSION.MessageObj())
 		return
@@ -323,7 +323,7 @@ func (h *Handler) handleClientAuthWithServer(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if !h.CheckLauncherVersion(r) {
+	if !h.CheckLauncherVersion(r, true) {
 		h.m().client_authwithserver_requests_total.reject_versiongate.Inc()
 		respFail(w, r, http.StatusBadRequest, ErrorCode_UNSUPPORTED_VERSION.MessageObj())
 		return
@@ -479,7 +479,7 @@ func (h *Handler) handleClientAuthWithSelf(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if !h.CheckLauncherVersion(r) {
+	if !h.CheckLauncherVersion(r, true) {
 		h.m().client_authwithself_requests_total.reject_versiongate.Inc()
 		respFail(w, r, http.StatusBadRequest, ErrorCode_UNSUPPORTED_VERSION.MessageObj())
 		return

--- a/pkg/api/api0/server.go
+++ b/pkg/api/api0/server.go
@@ -54,7 +54,7 @@ func (h *Handler) handleServerUpsert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.CheckLauncherVersion(r) {
+	if !h.CheckLauncherVersion(r, false) {
 		h.m().server_upsert_requests_total.reject_versiongate(action).Inc()
 		respFail(w, r, http.StatusBadRequest, ErrorCode_UNSUPPORTED_VERSION.MessageObj())
 		return

--- a/pkg/atlas/config.go
+++ b/pkg/atlas/config.go
@@ -106,6 +106,16 @@ type Config struct {
 	// allowed.
 	API0_MinimumLauncherVersion string `env:"ATLAS_API0_MINIMUM_LAUNCHER_VERSION"`
 
+	// Minimum launcher semver to allow for authenticated clients, replacing
+	// ATLAS_API0_MINIMUM_LAUNCHER_VERSION. Dev versions are always allowed. If
+	// not provided, API0_MinimumLauncherVersion is used.
+	API0_MinimumLauncherVersionClient string `env:"ATLAS_API0_MINIMUM_LAUNCHER_VERSION_CLIENT"`
+
+	// Minimum launcher semver to allow for servers, replacing
+	// ATLAS_API0_MINIMUM_LAUNCHER_VERSION. Dev versions are always allowed. If
+	// not provided, API0_MinimumLauncherVersion is used.
+	API0_MinimumLauncherVersionServer string `env:"ATLAS_API0_MINIMUM_LAUNCHER_VERSION_SERVER"`
+
 	// Region mapping to use for server list. If set to an empty string or
 	// "none", region maps are disabled. Options: none, default.
 	API0_RegionMap string `env:"ATLAS_API0_REGION_MAP?=default"`

--- a/pkg/atlas/server.go
+++ b/pkg/atlas/server.go
@@ -59,6 +59,12 @@ func NewServer(c *Config) (*Server, error) {
 	if c.API0_MinimumLauncherVersion != "" && !semver.IsValid("v"+strings.TrimPrefix(c.API0_MinimumLauncherVersion, "v")) {
 		return nil, fmt.Errorf("invalid minimum launcher version semver %q", c.API0_MinimumLauncherVersion)
 	}
+	if c.API0_MinimumLauncherVersionClient != "" && !semver.IsValid("v"+strings.TrimPrefix(c.API0_MinimumLauncherVersionClient, "v")) {
+		return nil, fmt.Errorf("invalid minimum launcher client version semver %q", c.API0_MinimumLauncherVersionClient)
+	}
+	if c.API0_MinimumLauncherVersionServer != "" && !semver.IsValid("v"+strings.TrimPrefix(c.API0_MinimumLauncherVersionServer, "v")) {
+		return nil, fmt.Errorf("invalid minimum launcher server version semver %q", c.API0_MinimumLauncherVersionServer)
+	}
 
 	var s Server
 	var success bool
@@ -269,9 +275,18 @@ func NewServer(c *Config) (*Server, error) {
 		MaxServers:                   c.API0_MaxServers,
 		MaxServersPerIP:              c.API0_MaxServersPerIP,
 		InsecureDevNoCheckPlayerAuth: c.API0_InsecureDevNoCheckPlayerAuth,
-		MinimumLauncherVersion:       c.API0_MinimumLauncherVersion,
+		MinimumLauncherVersionClient: c.API0_MinimumLauncherVersionClient,
+		MinimumLauncherVersionServer: c.API0_MinimumLauncherVersionServer,
 		TokenExpiryTime:              c.API0_TokenExpiryTime,
 		AllowGameServerIPv6:          c.API0_AllowGameServerIPv6,
+	}
+	if v := c.API0_MinimumLauncherVersion; v != "" {
+		if s.API0.MinimumLauncherVersionClient == "" {
+			s.API0.MinimumLauncherVersionClient = v
+		}
+		if s.API0.MinimumLauncherVersionServer == "" {
+			s.API0.MinimumLauncherVersionServer = v
+		}
 	}
 
 	s.API0.NotFound = new(middlewares).
@@ -703,7 +718,7 @@ func configureMainMenuPromosUpdateNeeded(c *Config, h *api0.Handler) error {
 			if fn1 != nil {
 				mmp = fn1(r)
 			}
-			if r == nil || !h.CheckLauncherVersion(r) {
+			if r == nil || !h.CheckLauncherVersion(r, true) {
 				if buf, err1 := os.ReadFile(p); err1 != nil {
 					err = err1
 				} else if err = json.Unmarshal(buf, &mmp); err != nil {


### PR DESCRIPTION
Remains backwards-compatible with old configuration. No changes to the metrics since we can already differentiate version gate failures by request endpoint.

Closes #27 