### PR TITLE
Add support for using EAX for username lookup

### DIFF
--- a/pkg/api/api0/api.go
+++ b/pkg/api/api0/api.go
@@ -43,8 +43,11 @@ type Handler struct {
 	// PdataStorage stores player data. It must be non-nil.
 	PdataStorage PdataStorage
 
-	// OriginAuthMgr manages Origin nucleus tokens (used for checking
-	// usernames). If not provided, usernames will not be updated.
+	// UsernameSource configures the source to use for usernames.
+	UsernameSource UsernameSource
+
+	// OriginAuthMgr, if provided, manages Origin nucleus tokens for checking
+	// usernames.
 	OriginAuthMgr *origin.AuthMgr
 
 	// CleanBadWords is used to filter bad words from server names and

--- a/pkg/api/api0/api.go
+++ b/pkg/api/api0/api.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/klauspost/compress/gzip"
 	"github.com/pg9182/ip2x"
+	"github.com/r2northstar/atlas/pkg/eax"
 	"github.com/r2northstar/atlas/pkg/metricsx"
 	"github.com/r2northstar/atlas/pkg/origin"
 	"github.com/rs/zerolog/hlog"
@@ -49,6 +50,9 @@ type Handler struct {
 	// OriginAuthMgr, if provided, manages Origin nucleus tokens for checking
 	// usernames.
 	OriginAuthMgr *origin.AuthMgr
+
+	// EAXClient makes requests to the EAX API.
+	EAXClient *eax.Client
 
 	// CleanBadWords is used to filter bad words from server names and
 	// descriptions. If not provided, words will not be filtered.

--- a/pkg/api/api0/client.go
+++ b/pkg/api/api0/client.go
@@ -143,6 +143,12 @@ func (h *Handler) handleClientOriginAuth(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	select {
+	case <-r.Context().Done(): // check if the request was canceled to avoid making unnecessary requests
+		return
+	default:
+	}
+
 	if !h.InsecureDevNoCheckPlayerAuth {
 		token := r.URL.Query().Get("token")
 		if token == "" {
@@ -211,7 +217,19 @@ func (h *Handler) handleClientOriginAuth(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	select {
+	case <-r.Context().Done(): // check if the request was canceled to avoid making unnecessary requests
+		return
+	default:
+	}
+
 	username := h.lookupUsername(r, uid)
+
+	select {
+	case <-r.Context().Done(): // check if the request was canceled to avoid making unnecessary requests
+		return
+	default:
+	}
 
 	// note: there's small chance of race conditions here if there are multiple
 	// concurrent origin_auth calls, but since we only ever support one session
@@ -340,6 +358,11 @@ func (h *Handler) lookupUsername(r *http.Request, uid uint64) (username string) 
 // lookupUsernameOrigin gets the username for uid from the Origin API, returning
 // an empty string if a username does not exist for the uid, and false on error.
 func (h *Handler) lookupUsernameOrigin(r *http.Request, uid uint64) (username string, ok bool) {
+	select {
+	case <-r.Context().Done(): // check if the request was canceled to avoid polluting the metrics
+		return
+	default:
+	}
 	if h.OriginAuthMgr == nil {
 		hlog.FromRequest(r).Error().
 			Str("username_source", "origin").
@@ -402,6 +425,11 @@ func (h *Handler) lookupUsernameOrigin(r *http.Request, uid uint64) (username st
 // lookupUsernameEAX gets the username for uid from the EAX API, returning an
 // empty string if a username does not exist for the uid, and false on error.
 func (h *Handler) lookupUsernameEAX(r *http.Request, uid uint64) (username string, ok bool) {
+	select {
+	case <-r.Context().Done(): // check if the request was canceled to avoid polluting the metrics
+		return
+	default:
+	}
 	if h.EAXClient == nil {
 		hlog.FromRequest(r).Error().
 			Str("username_source", "eax").

--- a/pkg/api/api0/metrics.go
+++ b/pkg/api/api0/metrics.go
@@ -79,6 +79,13 @@ type apiMetrics struct {
 		fail_authtok_refresh *metrics.Counter
 		fail_other_error     *metrics.Counter
 	}
+	client_originauth_eax_username_lookup_duration_seconds *metrics.Histogram
+	client_originauth_eax_username_lookup_calls_total      struct {
+		success           *metrics.Counter
+		notfound          *metrics.Counter
+		fail_update_check *metrics.Counter
+		fail_other_error  *metrics.Counter
+	}
 	client_authwithserver_requests_total struct {
 		success                    *metrics.Counter
 		reject_bad_request         *metrics.Counter
@@ -246,6 +253,11 @@ func (h *Handler) m() *apiMetrics {
 		mo.client_originauth_origin_username_lookup_calls_total.notfound = mo.set.NewCounter(`atlas_api0_client_originauth_origin_username_lookup_calls_total{result="notfound"}`)
 		mo.client_originauth_origin_username_lookup_calls_total.fail_authtok_refresh = mo.set.NewCounter(`atlas_api0_client_originauth_origin_username_lookup_calls_total{result="fail_authtok_refresh"}`)
 		mo.client_originauth_origin_username_lookup_calls_total.fail_other_error = mo.set.NewCounter(`atlas_api0_client_originauth_origin_username_lookup_calls_total{result="fail_other_error"}`)
+		mo.client_originauth_eax_username_lookup_duration_seconds = mo.set.NewHistogram(`atlas_api0_client_originauth_eax_username_lookup_duration_seconds`)
+		mo.client_originauth_eax_username_lookup_calls_total.success = mo.set.NewCounter(`atlas_api0_client_originauth_eax_username_lookup_calls_total{result="success"}`)
+		mo.client_originauth_eax_username_lookup_calls_total.notfound = mo.set.NewCounter(`atlas_api0_client_originauth_eax_username_lookup_calls_total{result="notfound"}`)
+		mo.client_originauth_eax_username_lookup_calls_total.fail_update_check = mo.set.NewCounter(`atlas_api0_client_originauth_eax_username_lookup_calls_total{result="fail_update_check"}`)
+		mo.client_originauth_eax_username_lookup_calls_total.fail_other_error = mo.set.NewCounter(`atlas_api0_client_originauth_eax_username_lookup_calls_total{result="fail_other_error"}`)
 		mo.client_authwithserver_requests_total.success = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="success"}`)
 		mo.client_authwithserver_requests_total.reject_bad_request = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_bad_request"}`)
 		mo.client_authwithserver_requests_total.reject_versiongate = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_versiongate"}`)

--- a/pkg/atlas/config.go
+++ b/pkg/atlas/config.go
@@ -160,9 +160,15 @@ type Config struct {
 	// API0_MinimumLauncherVersion.
 	API0_MainMenuPromos_UpdateNeeded string `env:"ATLAS_API0_MAINMENUPROMOS_UPDATENEEDED=none"`
 
-	// The email address to use for Origin login. If not provided, usernames are
-	// not resolved during authentication. If it begins with @, it is treated
-	// as the name of a systemd credential to load.
+	// Sets the source used for resolving usernames. If not specified, "origin"
+	// is used if OriginEmail is provided, otherwise, "none" is used.
+	//  - none (don't get usernames)
+	//  - origin (get the username from the Origin API)
+	UsernameSource string `env:"ATLAS_USERNAMESOURCE"`
+
+	// The email address to use for Origin login. If not provided, the Origin
+	// API will not be used. If it begins with @, it is treated as the name of a
+	// systemd credential to load.
 	OriginEmail string `env:"ATLAS_ORIGIN_EMAIL" sdcreds:"load,trimspace"`
 
 	// The password for Origin login. If it begins with @, it is treated as the

--- a/pkg/atlas/config.go
+++ b/pkg/atlas/config.go
@@ -194,6 +194,18 @@ type Config struct {
 	// restarts. Highly recommended.
 	OriginPersist string `env:"ATLAS_ORIGIN_PERSIST"`
 
+	// Override the EAX EA App version. If specified, updates will not be
+	// checked automatically.
+	EAXUpdateVersion string `env:"EAX_UPDATE_VERSION"`
+
+	// EAXUpdateInterval is the min interval at which to check for EA App
+	// updates.
+	EAXUpdateInterval time.Duration `env:"EAX_UPDATE_INTERVAL=24h"`
+
+	// EAXUpdateBucket is the update bucket to use when checking for EA App
+	// updates.
+	EAXUpdateBucket int `env:"EAX_UPDATE_BUCKET=0"`
+
 	// Secret token for accessing internal metrics. If it begins with @, it is
 	// treated as the name of a systemd credential to load.
 	MetricsSecret string `env:"ATLAS_METRICS_SECRET" sdcreds:"load,trimspace"`

--- a/pkg/atlas/config.go
+++ b/pkg/atlas/config.go
@@ -164,6 +164,10 @@ type Config struct {
 	// is used if OriginEmail is provided, otherwise, "none" is used.
 	//  - none (don't get usernames)
 	//  - origin (get the username from the Origin API)
+	//  - origin-eax (get the username from the Origin API, but fall back to EAX on failure)
+	//  - origin-eax-debug (get the username from the Origin API, but also check EAX and warn if it's different)
+	//  - eax (get the username from EAX)
+	//  - eax-origin (get the username from EAX, but fall back to the Origin API on failure)
 	UsernameSource string `env:"ATLAS_USERNAMESOURCE"`
 
 	// The email address to use for Origin login. If not provided, the Origin

--- a/pkg/atlas/server.go
+++ b/pkg/atlas/server.go
@@ -517,7 +517,9 @@ func configureOrigin(c *Config, l zerolog.Logger) (*origin.AuthMgr, error) {
 				}
 			}
 			if err != nil {
-				l.Err(err).Msg("origin auth error")
+				l.Err(err).Msg("origin auth error; using old token")
+			} else {
+				l.Info().Msg("got new origin token")
 			}
 		},
 	}
@@ -615,7 +617,9 @@ func configureEAX(c *Config, l zerolog.Logger) (*eax.Client, error) {
 		AutoUpdateBackoff: expbackoff,
 		AutoUpdateHook: func(ver string, err error) {
 			if err != nil {
-				l.Err(err).Msg("eax update error")
+				l.Err(err).Str("eax_client_version", ver).Msg("eax update error, using old version")
+			} else {
+				l.Info().Str("eax_client_version", ver).Msg("updated eax client version")
 			}
 		},
 	}

--- a/pkg/atlas/server.go
+++ b/pkg/atlas/server.go
@@ -649,6 +649,14 @@ func configureUsernameSource(c *Config) (api0.UsernameSource, error) {
 		return api0.UsernameSourceNone, nil
 	case "origin":
 		return api0.UsernameSourceOrigin, nil
+	case "origin-eax":
+		return api0.UsernameSourceOriginEAX, nil
+	case "origin-eax-debug":
+		return api0.UsernameSourceOriginEAXDebug, nil
+	case "eax":
+		return api0.UsernameSourceEAX, nil
+	case "eax-origin":
+		return api0.UsernameSourceEAXOrigin, nil
 	case "":
 		// backwards compat
 		if c.OriginEmail != "" {

--- a/pkg/eax/eax.go
+++ b/pkg/eax/eax.go
@@ -1,0 +1,145 @@
+// Package eax queries the EA App API.
+package eax
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+type Client struct {
+	// The [net/http.Client] to use for requests. If not provided,
+	// [net/http.DefaultClient] is used.
+	Client *http.Client
+
+	// The UpdateMgr for requests which require version information.
+	UpdateMgr *UpdateMgr
+}
+
+var ErrVersionRequired = errors.New("client version is required for this endpoint")
+
+// PlayerID contains basic identifiers and names for a player.
+type PlayerID struct {
+	PD          uint64 // origin ID
+	PSD         uint64 // ?
+	DisplayName string // in-game name
+	Nickname    string // social name?
+}
+
+// PlayerByPd gets basic information about an Origin ID. If the player does not
+// exist, nil will be returned.
+func (c *Client) PlayerIDByPD(ctx context.Context, pd uint64) (*PlayerID, error) {
+	var obj struct {
+		PlayerByPD *struct {
+			PD          string `json:"pd"`
+			PSD         string `json:"psd"`
+			DisplayName string `json:"displayName"`
+			Nickname    string `json:"nickname"`
+		} `json:"playerByPd"`
+	}
+	if err := c.gql1(ctx, true, `query { playerByPd (pd: `+strconv.FormatUint(pd, 10)+`) { pd psd displayName nickname } }`, &obj); err != nil {
+		return nil, err
+	}
+	if obj.PlayerByPD == nil {
+		return nil, nil
+	}
+	res := &PlayerID{
+		DisplayName: obj.PlayerByPD.DisplayName,
+		Nickname:    obj.PlayerByPD.Nickname,
+	}
+	if s := obj.PlayerByPD.PD; s != "" {
+		if v, err := strconv.ParseUint(s, 10, 64); err == nil {
+			res.PD = v
+		} else {
+			return res, fmt.Errorf("parse pd %q: %w", s, err)
+		}
+	}
+	if s := obj.PlayerByPD.PSD; s != "" {
+		if v, err := strconv.ParseUint(s, 10, 64); err == nil {
+			res.PD = v
+		} else {
+			return res, fmt.Errorf("parse psd %q: %w", s, err)
+		}
+	}
+	return res, nil
+}
+
+// gql1 performs a basic GraphQL query.
+func (c *Client) gql1(ctx context.Context, ver bool, query string, out any) error {
+	req, err := c.req(ctx, ver, http.MethodGet, "https://service-aggregation-layer.juno.ea.com/graphql?query="+url.QueryEscape(query), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if mt, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type")); mt != "application/json" {
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("response status %d (%s) with content-type %q", resp.StatusCode, resp.Status, mt)
+		}
+		return fmt.Errorf("unexpected content-type %q", mt)
+	}
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var obj struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(buf, &obj); err != nil {
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("response status %d (%s) with invalid json", resp.StatusCode, resp.Status)
+		}
+		return fmt.Errorf("invalid json resp: %w", err)
+	}
+	if len(obj.Errors) != 0 {
+		return fmt.Errorf("got %d errors, including %q", len(obj.Errors), obj.Errors[0].Message)
+	}
+	if err := json.Unmarshal([]byte(obj.Data), out); err != nil {
+		return fmt.Errorf("invalid json data: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) do(r *http.Request) (*http.Response, error) {
+	if c.Client == nil {
+		return http.DefaultClient.Do(r)
+	}
+	return c.Client.Do(r)
+}
+
+func (c *Client) req(ctx context.Context, ver bool, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err == nil {
+		if ver {
+			if c.UpdateMgr == nil {
+				return nil, ErrVersionRequired
+			}
+			ver, _, err := c.UpdateMgr.Update(false)
+			if err != nil {
+				return nil, fmt.Errorf("%w: failed to update version: %v", ErrVersionRequired, err)
+			}
+			if ver == "" {
+				return nil, ErrVersionRequired
+			}
+			req.Header.Set("User-Agent", "EADesktop/"+ver)
+		}
+		req.Header.Set("x-client-id", "EAX-JUNO-CLIENT")
+	}
+	return req, err
+}

--- a/pkg/eax/updatemgr.go
+++ b/pkg/eax/updatemgr.go
@@ -1,0 +1,180 @@
+package eax
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// UpdateMgr manages EAX client version information.
+type UpdateMgr struct {
+	// HTTP client to use. If not provided, [net/http.DefaultClient] will be
+	// used.
+	Client *http.Client
+
+	// Timeout is the timeout for refreshing tokens. If zero, a reasonable
+	// default is used. If negative, there is no timeout.
+	Timeout time.Duration
+
+	// Interval to update at. If zero, will not auto-update.
+	AutoUpdateInterval time.Duration
+
+	// Auto-update staged roll-out bucket.
+	AutoUpdateBucket int
+
+	// Auto-update backoff, if provided, checks if another auto-update is
+	// allowed after a failure. If it returns false, ErrAutoUpdateBackoff will be
+	// returned from the function triggering the auto-update.
+	AutoUpdateBackoff func(err error, time time.Time, count int) bool
+
+	// AutoUpdateHook is called for every auto-update attempt with the new (or
+	// current if error) version, and any error which occurred.
+	AutoUpdateHook func(v string, err error)
+
+	verInit     sync.Once
+	verPf       bool       // ensures only one auto-update runs at a time
+	verCv       *sync.Cond // allows other goroutines to wait for that update to complete
+	verErr      error      // last auto-update error
+	verErrTime  time.Time  // last auto-update error time
+	verErrCount int        // consecutive auto-update errors
+	ver         string     // current version
+	verTime     time.Time  // last update check time
+}
+
+var ErrAutoUpdateBackoff = errors.New("not updating eax client version due to backoff")
+
+func (u *UpdateMgr) init() {
+	u.verInit.Do(func() {
+		u.verCv = sync.NewCond(new(sync.Mutex))
+	})
+}
+
+// SetVersion sets the current version.
+func (u *UpdateMgr) SetVersion(v string) {
+	u.init()
+	u.verCv.L.Lock()
+	for u.verPf {
+		u.verCv.Wait()
+	}
+	u.ver = v
+	u.verErr = nil
+	u.verTime = time.Now()
+	u.verCv.L.Unlock()
+}
+
+// Update gets the latest version, following u.AutoUpdateInterval if provided,
+// unless the version is not set or force is true. If another update is in
+// progress, it waits for the result of it. True is returned (on success or
+// failure) if this call performed a update. This function may block for up to
+// Timeout.
+func (u *UpdateMgr) Update(force bool) (string, bool, error) {
+	u.init()
+	if u.verCv.L.Lock(); u.verPf {
+		for u.verPf {
+			u.verCv.Wait()
+		}
+		defer u.verCv.L.Unlock()
+		return u.ver, false, u.verErr
+	} else {
+		if force || u.ver == "" || (u.AutoUpdateInterval != 0 && time.Since(u.verTime) > u.AutoUpdateInterval) {
+			u.verPf = true
+			u.verCv.L.Unlock()
+			defer func() {
+				u.verCv.L.Lock()
+				u.verCv.Broadcast()
+				u.verPf = false
+				u.verCv.L.Unlock()
+			}()
+		} else {
+			defer u.verCv.L.Unlock()
+			return u.ver, false, u.verErr
+		}
+	}
+	if u.verErr != nil && u.AutoUpdateBackoff != nil {
+		if !u.AutoUpdateBackoff(u.verErr, u.verErrTime, u.verErrCount) {
+			return u.ver, true, fmt.Errorf("%w (%d attempts, last error: %v)", ErrAutoUpdateBackoff, u.verErrCount, u.verErr)
+		}
+	}
+	u.verErr = func() error {
+		var ctx context.Context
+		var cancel context.CancelFunc
+		if u.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), u.Timeout)
+		} else if u.Timeout == 0 {
+			ctx, cancel = context.WithTimeout(context.Background(), time.Second*15)
+		} else {
+			ctx, cancel = context.WithCancel(context.Background())
+		}
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://autopatch.juno.ea.com/autopatch/upgrade/buckets/"+strconv.Itoa(u.AutoUpdateBucket), nil)
+		if err != nil {
+			return err
+		}
+		if u.ver != "" {
+			req.Header.Set("User-Agent", "EADesktop/"+u.ver)
+		} else {
+			req.Header.Set("User-Agent", "")
+		}
+
+		cl := u.Client
+		if cl == nil {
+			cl = http.DefaultClient
+		}
+
+		resp, err := cl.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		var obj struct {
+			Minimum struct {
+				Version        string `json:"version"`
+				ActivationDate string `json:"activationDate"`
+			} `json:"minimum"`
+			Recommended struct {
+				Version string `json:"version"`
+			} `json:"recommended"`
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("response status %d (%s)", resp.StatusCode, resp.Status)
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&obj); err != nil {
+			return fmt.Errorf("parse autopatch response: %w", err)
+		}
+
+		var version string
+		if v := obj.Minimum.Version; v != "" {
+			version = v
+		}
+		if v := obj.Recommended.Version; v != "" {
+			version = v
+		}
+		if version == "" {
+			return fmt.Errorf("parse autopatch response: missing minimum or recommended version")
+		}
+		u.ver = version
+		u.verTime = time.Now()
+		return nil
+	}()
+	if u.verErrCount != 0 {
+		u.verErr = fmt.Errorf("%w (attempt %d)", u.verErr, u.verErrCount)
+	}
+	if u.verErr != nil {
+		u.verErrCount++
+		u.verErrTime = time.Now()
+	} else {
+		u.verErrCount = 0
+		u.verErrTime = time.Time{}
+	}
+	if u.AutoUpdateHook != nil {
+		go u.AutoUpdateHook(u.ver, u.verErr)
+	}
+	return u.ver, true, u.verErr
+}


### PR DESCRIPTION
Also allow for combinations of the Origin API and EAX.

Why EAX:
- They should theoretically be the same, EAX is the new API for EA Desktop.
- Thus, there's a possibility it will work better on some of the edge cases where origin's username is possibly incorrect or missing, and it'll also continue to work if the origin API is discontinued.
- This EAX endpoint doesn't require authentication to use.