### PR TITLE
Allow game servers to reject connections with a reason

### DIFF
--- a/pkg/api/api0/errors.go
+++ b/pkg/api/api0/errors.go
@@ -21,6 +21,7 @@ const (
 	ErrorCode_JSON_PARSE_ERROR           ErrorCode = "JSON_PARSE_ERROR"           // Error parsing json response
 	ErrorCode_UNSUPPORTED_VERSION        ErrorCode = "UNSUPPORTED_VERSION"        // The version you are using is no longer supported
 	ErrorCode_DUPLICATE_SERVER           ErrorCode = "DUPLICATE_SERVER"           // A server with this port already exists for your IP address
+	ErrorCode_CONNECTION_REJECTED        ErrorCode = "CONNECTION_REJECTED"        // Connection rejected
 )
 
 const (
@@ -88,6 +89,8 @@ func (n ErrorCode) Message() string {
 		return "Internal server error"
 	case ErrorCode_BAD_REQUEST:
 		return "Bad request"
+	case ErrorCode_CONNECTION_REJECTED:
+		return "Connection rejected"
 	default:
 		return string(n)
 	}

--- a/pkg/api/api0/metrics.go
+++ b/pkg/api/api0/metrics.go
@@ -94,6 +94,7 @@ type apiMetrics struct {
 		reject_masterserver_token  *metrics.Counter
 		reject_password            *metrics.Counter
 		reject_gameserverauth      *metrics.Counter
+		reject_gameserver          *metrics.Counter
 		fail_gameserverauth        *metrics.Counter
 		fail_storage_error_account *metrics.Counter
 		fail_storage_error_pdata   *metrics.Counter
@@ -265,6 +266,7 @@ func (h *Handler) m() *apiMetrics {
 		mo.client_authwithserver_requests_total.reject_masterserver_token = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_masterserver_token"}`)
 		mo.client_authwithserver_requests_total.reject_password = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_password"}`)
 		mo.client_authwithserver_requests_total.reject_gameserverauth = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_gameserverauth"}`)
+		mo.client_authwithserver_requests_total.reject_gameserver = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="reject_gameserver"}`)
 		mo.client_authwithserver_requests_total.fail_gameserverauth = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="fail_gameserverauth"}`)
 		mo.client_authwithserver_requests_total.fail_storage_error_account = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="fail_storage_error_account"}`)
 		mo.client_authwithserver_requests_total.fail_storage_error_pdata = mo.set.NewCounter(`atlas_api0_client_authwithserver_requests_total{result="fail_storage_error_pdata"}`)


### PR DESCRIPTION
This is backwards-compatible with old clients, since it implements it as a new error type.

for R2Northstar/NorthstarLauncher#431