### PR TITLE
pkg/api/api0: Update UNSUPPORTED_VERSION error message

### DIFF
--- a/pkg/api/api0/errors.go
+++ b/pkg/api/api0/errors.go
@@ -20,7 +20,7 @@ const (
 	ErrorCode_GAMESERVER_NOT_FOUND       ErrorCode = "GAMESERVER_NOT_FOUND"       // Couldn't find game server
 	ErrorCode_INVALID_MASTERSERVER_TOKEN ErrorCode = "INVALID_MASTERSERVER_TOKEN" // Invalid or expired masterserver token
 	ErrorCode_JSON_PARSE_ERROR           ErrorCode = "JSON_PARSE_ERROR"           // Error parsing json response
-	ErrorCode_UNSUPPORTED_VERSION        ErrorCode = "UNSUPPORTED_VERSION"        // The version you are using is no longer supported
+	ErrorCode_UNSUPPORTED_VERSION        ErrorCode = "UNSUPPORTED_VERSION"        // The version you are using is no longer supported; update Northstar to continue
 	ErrorCode_DUPLICATE_SERVER           ErrorCode = "DUPLICATE_SERVER"           // A server with this port already exists for your IP address
 	ErrorCode_CONNECTION_REJECTED        ErrorCode = "CONNECTION_REJECTED"        // Connection rejected
 )

--- a/pkg/api/api0/errors.go
+++ b/pkg/api/api0/errors.go
@@ -85,7 +85,7 @@ func (n ErrorCode) Message() string {
 	case ErrorCode_JSON_PARSE_ERROR:
 		return "Error parsing json response"
 	case ErrorCode_UNSUPPORTED_VERSION:
-		return "The version you are using is no longer supported"
+		return "The version you are using is no longer supported. Update Northstar to continue."
 	case ErrorCode_DUPLICATE_SERVER:
 		return "A server with this port already exists for your IP address"
 	case ErrorCode_INTERNAL_SERVER_ERROR:

--- a/pkg/api/api0/errors.go
+++ b/pkg/api/api0/errors.go
@@ -85,7 +85,7 @@ func (n ErrorCode) Message() string {
 	case ErrorCode_JSON_PARSE_ERROR:
 		return "Error parsing json response"
 	case ErrorCode_UNSUPPORTED_VERSION:
-		return "The version you are using is no longer supported. Update Northstar to continue."
+		return "The version you are using is no longer supported; update Northstar to continue"
 	case ErrorCode_DUPLICATE_SERVER:
 		return "A server with this port already exists for your IP address"
 	case ErrorCode_INTERNAL_SERVER_ERROR:


### PR DESCRIPTION
Explicitly tell the user that they need to update Northstar.

I've seen multiple cases of users seeing the current error message and not understanding that they need to update Northstar, this should alleviate that somewhat I hope.

The exact wording I'm not too sure on, but this should do for now