### PR TITLE
Implement isDraining flag for servers

### DIFF
--- a/pkg/api/api0/server.go
+++ b/pkg/api/api0/server.go
@@ -284,6 +284,15 @@ func (h *Handler) handleServerUpsert(w http.ResponseWriter, r *http.Request) {
 				u.MaxPlayers = &x
 			}
 		}
+
+		if v, err := strconv.ParseBool(q.Get("isDraining")); err == nil {
+			if canCreate {
+				s.IsDraining = v
+			}
+			if canUpdate {
+				u.IsDraining = &v
+			}
+		}
 	}
 
 	if canCreate {


### PR DESCRIPTION
* For backwards compatibility and doing what makes sense, the max players in metrics and the server list is set to the player count while a server is draining. Existing NorthstarMods versions will sort these servers to the end of the server list.
* NorthstarLauncher will enforce rejecting connections using the existing rejection mechanism while a server is draining.

R2Northstar/Northstar#544